### PR TITLE
DM-45273: Expand ap_pipe section of Science Pipelines Software Paper

### DIFF
--- a/PSTN-019.tex
+++ b/PSTN-019.tex
@@ -30,6 +30,8 @@
 \input{meas}
 \input{diffim}
 \input{jointcal}
+\input{association}
+\input{alerts}
 \input{pipe}
 \input{schemas}
 \input{display}

--- a/afw.tex
+++ b/afw.tex
@@ -1,4 +1,5 @@
 \section{Core Infrastructure Libraries}
+\label{sec:core}
 
 \subsection{Region Handling}
 

--- a/alerts.tex
+++ b/alerts.tex
@@ -1,0 +1,3 @@
+\section{Alert Generation and Distribution}
+
+\texttt{ap\_association}, \texttt{alert\_packet}

--- a/alerts.tex
+++ b/alerts.tex
@@ -1,3 +1,4 @@
 \section{Alert Generation and Distribution}
+\label{sec:alerts}
 
 \texttt{ap\_association}, \texttt{alert\_packet}

--- a/analysis.tex
+++ b/analysis.tex
@@ -1,4 +1,5 @@
 \section{Data Analysis}
+\label{sec:analysis}
 
 \texttt{analysis\_tools}
 \texttt{verify}

--- a/association.tex
+++ b/association.tex
@@ -1,3 +1,4 @@
 \section{Source Association}
+\label{sec:association}
 
 \texttt{ap\_association}, for both DiaSource and Solar System processing

--- a/association.tex
+++ b/association.tex
@@ -1,0 +1,3 @@
+\section{Source Association}
+
+\texttt{ap\_association}, for both DiaSource and Solar System processing

--- a/authors.yaml
+++ b/authors.yaml
@@ -6,3 +6,4 @@
 - lustnb
 - sullivanis
 - watersc
+- findeisenk

--- a/conclusions.tex
+++ b/conclusions.tex
@@ -1,3 +1,4 @@
 \section{Conclusions}
+\label{sec:conclusions}
 
 The LSST Science Pipelines Software has been developed over 20 years to support the processing of the Legacy Survey of Space and Time.

--- a/data-access.tex
+++ b/data-access.tex
@@ -72,6 +72,7 @@ The \texttt{exposure} record itself implies other information such as the physic
 A deep coadd on a patch of sky would not have \texttt{exposure} dimensions at all and would instead be something like \texttt{instrument="LSSTCam", tract=105, patch=2, skymap="something"}, which would tell you exactly where it is located in the sky since you can calculate it from the tract and patch and skymap.
 
 \subsection{Instrument Abstractions: Obs Packages}
+\label{sec:obs_packages}
 
 The Butler and pipeline construction code know nothing about the specifics of a particular instrument.
 In the default dimension universe there is an \texttt{instrument} dimension that includes a field containing the full name of a Python \texttt{Instrument} class.

--- a/data-access.tex
+++ b/data-access.tex
@@ -1,4 +1,5 @@
 \section{Data Access Abstraction}
+\label{sec:data-access}
 
 \subsection{Butler}
 

--- a/diffim.tex
+++ b/diffim.tex
@@ -1,3 +1,4 @@
 \section{Difference Imaging}
+\label{sec:diffim}
 
 \texttt{ip\_diffim}

--- a/display.tex
+++ b/display.tex
@@ -1,4 +1,5 @@
 \section{Display Abstractions}
+\label{sec:display}
 
 Display plugins for:
 

--- a/intro.tex
+++ b/intro.tex
@@ -1,4 +1,5 @@
 \section{Introduction}
+\label{sec:intro}
 
 The Vera C.\ Rubin Observatory will be performing the 10-year Legacy Survey of Space and Time \citep[LSST;][]{2019ApJ...873..111I} starting in 2025.
 Rubin Observatory is located on Cerro Pachon in Chile and consists of the 8.4\,m Simonyi Survey Telescope with the 3.4-gigapixel LSSTCam survey camera performing the main survey and the Rubin Auxiliary Telescope providing supplementary atmospheric calibration data.

--- a/isr.tex
+++ b/isr.tex
@@ -1,1 +1,2 @@
 \section{Instrument Signature Removal}
+\label{sec:isr}

--- a/jointcal.tex
+++ b/jointcal.tex
@@ -1,4 +1,5 @@
 \section{Astrometric and Photometric Calibration}
+\label{sec:jointcal}
 
 \subsection{Astrometric Calibration}
 

--- a/meas.tex
+++ b/meas.tex
@@ -1,4 +1,5 @@
 \section{Measurement System}
+\label{sec:meas}
 
 Measurement plugin system.
 

--- a/pipe.tex
+++ b/pipe.tex
@@ -1,4 +1,5 @@
 \section{Pipelines}
+\label{sec:pipe}
 
 \subsection{Pipeline Support}
 

--- a/pipe.tex
+++ b/pipe.tex
@@ -18,4 +18,11 @@ Maybe describe \texttt{pex\_config} because it's not described anywhere.
 \subsection{Pipeline Collections}
 
 \texttt{drp\_pipe}
-\texttt{ap\_pipe}
+
+The \texttt{ap\_pipe} package defines the pipeline(s) to be used for real-time Alert Production processing (\ref{}).
+These pipelines include instrument signature removal (\S\ref{sec:isr}), calibration (\S\ref{}), measurement plugins (\S\ref{sec:meas}), image differencing (\S\ref{sec:diffim}), source association (\S\ref{sec:association}), and alert generation (\S\ref{sec:alerts}).
+Some of these tasks are shared with the pipelines in \texttt{drp\_pipe}, but configured to prioritize speed over strict quality; for example, they use a minimal set of measurement plugins.
+
+\texttt{ap\_pipe} currently has pipeline variants for LATISS, the Rubin Observatory simulators, Hyper-SuprimeCam, and the Dark Energy Camera.
+Because these variants serve as testbeds for AP-specific algorithms and configuration settings, they are, as much as possible, the ``same'' pipeline, differing almost entirely in loading instrument defaults from \texttt{obs} packages (\S\ref{sec:obs_packages}).
+The only other customization is an extra task for handling DECam's inter-chip crosstalk, which does not have an equivalent for Rubin instruments.

--- a/schemas.tex
+++ b/schemas.tex
@@ -1,4 +1,5 @@
 \section{Catalog Schemas}
+\label{sec:schemas}
 
 Must transform pipeline products from the internal data model to the public data model defined in \citet{LSE-163}.
 

--- a/support.tex
+++ b/support.tex
@@ -1,4 +1,5 @@
 \section{Fundamentals}
+\label{sec:support}
 
 The LSST Science Pipelines software is written in Python with C++ used for high performance algorithms and for core classes that are usable in both languages.
 We use Python 3 \citep[having ported from python 2,][currently with a minimum version of Python 3.11]{2020ASPC..522..541J}, and the C++ layer can use C++17 features with pybind11 being used to provide the interface from Python to C++.

--- a/validation.tex
+++ b/validation.tex
@@ -1,4 +1,5 @@
 \section{Validating the Science Pipelines}
+\label{sec:validation}
 
 We use small, of order of a few gigabyte, datasets that can be processed as part of continuous integration.
 These take of order an hour to process.


### PR DESCRIPTION
This PR fleshes out the description of `ap_pipe`, and adds stubs for `ap_association` and `alert-packet`.

Built document is at https://pstn-019.lsst.io/v/DM-45273/.